### PR TITLE
Update mdast to remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This detects `<a name='foo'></a>` anchors and references to them like
 Rewrites
 
 ```md
-1. Foo bar
-  1. <a name='baz'></a> Baz
-2. <a name='bar'></a>This refers to [](#baz)
-3. And this refers to [](#bar)
+1.  Foo bar
+    1.  <a name='baz'></a> Baz
+2.  <a name='bar'></a>This refers to [](#baz)
+3.  And this refers to [](#bar)
 ```
 
 To

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mdast-cross-reference
+# remark-cross-reference
 
 A poor man's [LaTeX cross-referencing system](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing) in Markdown.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mdast-cross-reference",
+  "name": "remark-cross-reference",
   "version": "1.0.0",
   "description": "initialize and link up cross references between sections in a document",
   "main": "index.js",
@@ -7,14 +7,14 @@
     "test": "tap test/test.js"
   },
   "keywords": [
-    "mdast",
+    "remark",
     "cross",
     "reference"
   ],
   "author": "Tom MacWright",
   "license": "ISC",
   "devDependencies": {
-    "mdast": "^2.1.0",
+    "remark": "^3.1.0",
     "tap": "^5.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "devDependencies": {
     "mdast": "^2.1.0",
-    "tap": "^2.2.0"
+    "tap": "^5.0.0"
   },
   "dependencies": {
     "unist-builder": "^1.0.0",

--- a/test/fixtures/simple.input.md
+++ b/test/fixtures/simple.input.md
@@ -1,4 +1,4 @@
-1. Foo bar
-  1. <a name='baz'></a> Baz
-2. <a name='bar'></a>This refers to [](#baz)
-3. And this refers to [](#bar)
+1.  Foo bar
+    1.  <a name='baz'></a> Baz
+2.  <a name='bar'></a>This refers to [](#baz)
+3.  And this refers to [](#bar)

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,11 @@
 var fs = require('fs');
 var crossReference = require('../');
-var mdast = require('mdast');
+var remark = require('remark');
 var test = require('tap').test;
 
-test('mdast-cross-reference', function(t) {
+test('remark-cross-reference', function(t) {
   var input = fs.readFileSync(__dirname + '/fixtures/simple.input.md', 'utf8');
-  var output = mdast()
+  var output = remark()
     .use(crossReference)
     .process(input);
 


### PR DESCRIPTION
You’ll still need to do [these steps](https://github.com/wooorm/remark/blob/master/doc/plugins.md#renaming-from-mdast-to-remark) to complete the name change on GitHub / npm.
